### PR TITLE
Fix older git versions on Windows

### DIFF
--- a/R/git-auth.R
+++ b/R/git-auth.R
@@ -377,9 +377,17 @@ gitcreds_run <- function(command, input, args = character()) {
 git_run <- function(args, input = NULL) {
   stderr_file <- tempfile("gitcreds-stderr-")
   on.exit(unlink(stderr_file, recursive = TRUE), add = TRUE)
+  if (!is.null(input)) {
+    stdin_file <- tempfile("gitcreds-stdin-")
+    on.exit(unlink(stdin_file, recursive = TRUE), add = TRUE)
+    writeBin(charToRaw(input), stdin_file)
+    stdin <- stdin_file
+  } else {
+    stdin <- ""
+  }
   out <- tryCatch(
     suppressWarnings(system2(
-      "git", args, input = input, stdout = TRUE, stderr = stderr_file
+      "git", args, stdin = stdin, stdout = TRUE, stderr = stderr_file
     )),
     error = function(e) NULL
   )


### PR DESCRIPTION
The issue is that system2() uses writeLines()
to write out the standard input to a file, and this
uses \r\n EOLs on Windows. Older git versions
or git for Windows installers (before 2.25.1) do not
handle \r\n as EOL when dealing with credentials.