### PR TITLE
Add note about GitHub PAT expiration time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,5 @@ Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 SystemRequirements: git

--- a/R/aaa-doc.R
+++ b/R/aaa-doc.R
@@ -57,7 +57,8 @@
 #'
 #' To set up password-less authentication to GitHub:
 #' 1. Create a personal access token (PAT). See
-#'    https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token.
+#'    <https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token>.
+#'    Note that personal access tokens can expire, and the default expiration time is 30 days.
 #' 2. Call `gitcreds_set()` and give this token as the password.
 #' 3. Run `gitcreds_get(use_cache = FALSE)` to check that the new
 #'    PAT is set up. To see the token, you can run

--- a/man/gitcreds-package.Rd
+++ b/man/gitcreds-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{gitcreds-package}
 \alias{gitcreds-package}
-\alias{_PACKAGE}
 \title{gitcreds: Query 'git' Credentials from 'R'}
 \description{
 Query, set, delete credentials from the 'git' credential store. Manage 'GitHub' tokens and other 'git' credentials. This package is to be used by other packages that need to authenticate to 'GitHub' and/or other 'git' repositories.

--- a/man/gitcreds_get.Rd
+++ b/man/gitcreds_get.Rd
@@ -105,7 +105,8 @@ If you need to avoid installing git, see 'Environment variables' below.
 To set up password-less authentication to GitHub:
 \enumerate{
 \item Create a personal access token (PAT). See
-https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token.
+\url{https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token}.
+Note that personal access tokens can expire, and the default expiration time is 30 days.
 \item Call \code{gitcreds_set()} and give this token as the password.
 \item Run \code{gitcreds_get(use_cache = FALSE)} to check that the new
 PAT is set up. To see the token, you can run


### PR DESCRIPTION
Add note that GitHub PATs expire, with a default expiration of 30 days.