### PR TITLE
Fix typo in README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -185,7 +185,7 @@ msg <- function(wh) {
   msgs[wh]
 }
 
-my_private_repos <- function() {
+my_public_repos <- function() {
   token <- tryCatch(
     gitcreds::gitcreds_get(),
     gitcreds_nogit_error = function(e) stop(msg("no_git")),


### PR DESCRIPTION
Rename example function to `my_public_repos` since it seems to be listing public not private repos. 
