### PR TITLE
Change GITHUB_PAT_ prefix to more generic GIT_PAT_

### DIFF
--- a/R/git-auth.R
+++ b/R/git-auth.R
@@ -214,15 +214,15 @@ gitcreds <- local({
     # env vars cannot start with a number
     slug3 <- ifelse(grepl("^[0-9]", slug2), paste0("AT_", slug2), slug2)
 
-    paste0("GITHUB_PAT_", toupper(slug3))
+    paste0("GIT_PAT_", toupper(slug3))
   }
 
   gitcreds_get_cache <- function(ev) {
     val <- Sys.getenv(ev, NA_character_)
-    if (is.na(val) && ev == "GITHUB_PAT_GITHUB_COM") {
+    if (is.na(val) && ev == "GIT_PAT_GITHUB_COM") {
       val <- Sys.getenv("GITHUB_PAT", NA_character_)
     }
-    if (is.na(val) && ev == "GITHUB_PAT_GITHUB_COM") {
+    if (is.na(val) && ev == "GIT_PAT_GITHUB_COM") {
       val <- Sys.getenv("GITHUB_TOKEN", NA_character_)
     }
     if (is.na(val) || val == "") {

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,10 +1,10 @@
 gc_test_that("gitcreds_cache_envvvar", {
   cases <- list(
-    c("https://github.com", "GITHUB_PAT_GITHUB_COM"),
-    c("https://api.github.com/path/to/endpoint", "GITHUB_PAT_GITHUB_COM"),
-    c("https://jane@github.com", "GITHUB_PAT_JANE_AT_GITHUB_COM"),
-    c("https://another.site.github.com", "GITHUB_PAT_ANOTHER_SITE_GITHUB_COM"),
-    c("http://foo.bar", "GITHUB_PAT_FOO_BAR")
+    c("https://github.com", "GIT_PAT_GITHUB_COM"),
+    c("https://api.github.com/path/to/endpoint", "GIT_PAT_GITHUB_COM"),
+    c("https://jane@github.com", "GIT_PAT_JANE_AT_GITHUB_COM"),
+    c("https://another.site.github.com", "GIT_PAT_ANOTHER_SITE_GITHUB_COM"),
+    c("http://foo.bar", "GIT_PAT_FOO_BAR")
   )
 
   for (case in cases) {
@@ -23,70 +23,70 @@ gc_test_that("gitcreds_cache_envvvar", {
 
 gc_test_that("gitcreds_get_cache", {
   # single password
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "token"))
-  cred <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "token"))
+  cred <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")
   expect_s3_class(cred, "gitcreds")
   expect_equal(cred$password, "token")
 
   # username + password
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "user:pass"))
-  cred <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "user:pass"))
+  cred <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")
   expect_s3_class(cred, "gitcreds")
   expect_equal(cred$username, "user")
   expect_equal(cred$password, "pass")
 
   # fall back to GITHUB_PAT
   withr::local_envvar(c(
-    GITHUB_PAT_GITHUB_COM = NA_character_,
+    GIT_PAT_GITHUB_COM = NA_character_,
     GITHUB_PAT = "mytoken"
   ))
-  cred <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")
+  cred <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")
   expect_s3_class(cred, "gitcreds")
   expect_equal(cred$password, "mytoken")
 
   # fall back to GITHUB_TOKEN
   withr::local_envvar(c(
-    GITHUB_PAT_GITHUB_COM = NA_character_,
+    GIT_PAT_GITHUB_COM = NA_character_,
     GITHUB_PAT = NA_character_,
     GITHUB_TOKEN = "mytoken3"
   ))
-  cred <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")
+  cred <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")
   expect_s3_class(cred, "gitcreds")
   expect_equal(cred$password, "mytoken3")
 
   # Not set
   withr::local_envvar(c(
-    GITHUB_PAT_GITHUB_COM = NA_character_,
+    GIT_PAT_GITHUB_COM = NA_character_,
     GITHUB_PAT = NA_character_,
     GITHUB_TOKEN = NA_character_
   ))
-  expect_null(gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM"))
+  expect_null(gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM"))
 
   # Warn for invalid
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "what:is:this"))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "what:is:this"))
   expect_warning(
-    expect_null(gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")),
+    expect_null(gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")),
     "Invalid gitcreds credentials in env var"
   )
 
   # fails if it has to
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "FAIL"))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "FAIL"))
   expect_error(
-    gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM"),
+    gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM"),
     class = "gitcreds_no_credentials"
   )
 
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "FAIL:gitcreds_no_helper"))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "FAIL:gitcreds_no_helper"))
   expect_error(
-    gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM"),
+    gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM"),
     class = "gitcreds_no_helper"
   )
 })
 
 gc_test_that("gitcreds_set_cache", {
   # : is escaped
-  gitcreds$gitcreds_set_cache("GITHUB_PAT_GITHUB_COM", list("x:y" = "a:b"))
-  cred <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_COM")
+  gitcreds$gitcreds_set_cache("GIT_PAT_GITHUB_COM", list("x:y" = "a:b"))
+  cred <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_COM")
   expect_s3_class(cred, "gitcreds")
   expect_equal(cred$username, "x:y")
   expect_equal(cred$password, "a:b")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -20,12 +20,12 @@ test_that("set_env() NA unsets", {
 test_that("env var set to empty string is same as unset", {
   skip_on_os("windows")
 
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_ACME_COM = NA_character_))
+  withr::local_envvar(c(GIT_PAT_GITHUB_ACME_COM = NA_character_))
 
-  oenv <- gitcreds$set_env(c(GITHUB_PAT_GITHUB_ACME_COM = ""))
+  oenv <- gitcreds$set_env(c(GIT_PAT_GITHUB_ACME_COM = ""))
   on.exit(gitcreds$set_env(oenv), add = TRUE)
 
-  x <- gitcreds$gitcreds_get_cache("GITHUB_PAT_GITHUB_ACME_COM")
+  x <- gitcreds$gitcreds_get_cache("GIT_PAT_GITHUB_ACME_COM")
   expect_null(x)
 })
 

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -112,7 +112,7 @@ It is easiest to use the withr package to temporarily change this environment va
 ```{r}
 library(testthat)
 test_that("bad credentials from git", {
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "bad"))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "bad"))
   # Test code that calls gitcreds_get(), potentially downstream.
   # gitcreds_get() will return `bad` as the password.
   # Illustration:
@@ -135,7 +135,7 @@ test_that("another GitHub user", {
     "username:user1:",
     "password:secret"
   )
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = cred))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = cred))
   # Your test code comes here. This is just an illustration:
   print(gitcreds::gitcreds_get())
   expect_equal(gitcreds::gitcreds_get()$username, "user1")
@@ -147,7 +147,7 @@ If you want gitcreds to fail for a specific host, set the corresponding environm
 ```{r}
 library(testthat)
 test_that("no credentials from git", {
-  withr::local_envvar(c(GITHUB_PAT_GITHUB_COM = "FAIL"))
+  withr::local_envvar(c(GIT_PAT_GITHUB_COM = "FAIL"))
   # The test code that calls gitcreds_get() comes here.
   # It will fail with error "gitcreds_no_credentials"
   expect_error(
@@ -165,7 +165,7 @@ For example:
 library(testthat)
 test_that("no git installation", {
   withr::local_envvar(c(
-    GITHUB_PAT_GITHUB_COM = "FAIL:gitcreds_nogit_error"
+    GIT_PAT_GITHUB_COM = "FAIL:gitcreds_nogit_error"
   ))
   # Test code that calls gitcreds_get() comes here.
   # Illustration:


### PR DESCRIPTION
Change GITHUB_PAT_ prefix to more generic GIT_PAT_ to remove confusion for non-GitHub users

Fixes #56